### PR TITLE
Fix state updates triggered by actions

### DIFF
--- a/src/meru/state.py
+++ b/src/meru/state.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from dataclasses import fields
 import logging
 from typing import Type
 
@@ -33,7 +34,8 @@ async def request_states():
     state = await state_consumer.receive()
 
     for node in state.nodes:
-        STATES[node.__class__] = node
+        for f in fields(node):
+            setattr(STATES[node.__class__], f.name, getattr(node, f.name))
         logging.info(f"Loaded state from broker: {node.__class__.__name__}")
 
     return STATES


### PR DESCRIPTION
The state objects in `STATES` were overwritten with a new object whenever a state was received from the broker.  This lead to inconsistencies as the objects in `STATES` were no longer the same as those captured in the handlers in `STATE_ACTION_HANDLERS`.  This resulted in the processes not seeing the updated objects.

This change eliminates the creation of a new element by writing the fields of the state individually.

Fixes #4 